### PR TITLE
Amended the pathing of apmpath and quarkinstall.sc

### DIFF
--- a/tidal/tools/chocolateyinstall.ps1
+++ b/tidal/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
-﻿$packageName= 'tidalcycles'
+$packageName= 'tidalcycles'
 
 # refresh env vars after other packages have been installed
 
 $scpath = Join-Path $env:programfiles "SuperCollider-3.12.1"
-$apmpath = Join-Path $env:localappdata "atom\bin"
+$apmpath = Join-Path $env:localappdata "atom\app-1.60.0\resources\app\apm\bin"
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") + ";" + $scpath + ";" + $apmpath
 
 ### install tidalcycles Atom package
@@ -14,7 +14,7 @@ get-childitem $env:localappdata
 get-childitem $apmpath
 
 ### install SuperDirt
-$quarkinstall_path = $env:ChocolateyPackageFolder + '\tools\quarkinstall.sc'
+$quarkinstall_path = Join-Path $env:ChocolateyInstall  "\lib-bad\TidalCycles\tools\quarkinstall.sc"
 Write-Host 'Installing SuperDirt sound synth and sample library. This will probably take a long time.'
 sclang $quarkinstall_path
 


### PR DESCRIPTION
tested on fresh windows 10 vm, ps1 script working all the way up to cabal install
Need to continue testing on other fresh machines to verify that the pathing remains consistent and to continue troubleshooting of cabal updates

Changes:
1. $apmpath: atom\bin was not listed as a directory, resulting in the binary not being located

2. $quarkinstall_path: at time of testing, ChocolateyPackageFolder was not coming up as an environment variable despite being listed in the documentation
Have resorted to using $env:ChocolateyInstall and have formatted the quarkinstall_path to be made with a ps Join-Path