### PR TITLE
Bump GHC version and unpin

### DIFF
--- a/tidal/tidal.nuspec
+++ b/tidal/tidal.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>TidalCycles</id>
-    <version>1.7.8</version>
+    <version>1.9.2</version>
     <packageSourceUrl>https://github.com/tidalcycles/tidal-chocolatey/</packageSourceUrl>
     <title>TidalCycles for Windows</title>
     <owners>Mike Hodnick, Alex McLean</owners>
@@ -39,7 +39,7 @@
     <dependency id="sc3plugins" version="3.11.1"/>
     <dependency id="msys2" version="[20210604.0.0]" />
     <dependency id="cabal" version="[3.6.2.0]"/>
-    <dependency id="ghc" version="[8.10.7]"/>
+    <dependency id="ghc" version="[9.4.2]"/>
   </dependencies>
   </metadata>
   <files>

--- a/tidal/tidal.nuspec
+++ b/tidal/tidal.nuspec
@@ -37,9 +37,9 @@
     <dependency id="atom" version="1.58.0"/>
     <dependency id="supercollider" version="3.12.1.0" />
     <dependency id="sc3plugins" version="3.11.1"/>
-    <dependency id="msys2" version="[20210604.0.0]" />
-    <dependency id="cabal" version="[3.6.2.0]"/>
-    <dependency id="ghc" version="[9.4.2]"/>
+    <dependency id="msys2" version="20210604.0.0" />
+    <dependency id="cabal" version="3.6.2.0"/>
+    <dependency id="ghc" version="9.4.2"/>
   </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
GHC 9.4.2 is needed for Tidal 1.9. I also don't see a strong case for pinning the dependency versions right now.