### PR TITLE
Pin Tidal version

### DIFF
--- a/tidal/tools/chocolateyinstall.ps1
+++ b/tidal/tools/chocolateyinstall.ps1
@@ -21,7 +21,7 @@ sclang $quarkinstall_path
 # Finally, install Tidal
 Write-Host "Installing tidal library. This will also take a long time." 
 cabal update
-cabal v1-install tidal
+cabal v2-install --lib tidal-1.9.2
 
 Write-Host 'Done.'
 Write-Host 'd1 $ sound "bd sn"'


### PR DESCRIPTION
By pinning the Tidal version, it becomes possible to install older versions of Tidal via chocolatey.
The drawback is that we need to publish a new version of the chocolatey package whenever we release.
I want your feedback. It might not be worth the effort. If we don't do this, should we change the Chocolatey description to mention that newer version of Tidal might be installed? Or are we good as it is?

Requires https://github.com/tidalcycles/tidal-chocolatey/pull/8.